### PR TITLE
Fix variant type inference issues

### DIFF
--- a/ui/TargetSelector.gd
+++ b/ui/TargetSelector.gd
@@ -82,16 +82,16 @@ func _create_arrow_texture() -> Texture2D:
 	
 	# Draw a yellow arrow (inverted V shape pointing down)
 	for y in range(16, 26):
-		var width := (y - 15) * 2
-		for x in range(16 - width/2, 16 + width/2 + 1):
+		var width: int = (y - 15) * 2
+		for x in range(16 - width // 2, 16 + width // 2 + 1):
 			if x >= 0 and x < 32:
 				img.set_pixel(x, y, Color(1, 1, 0))
 	
 	# Add black outline
 	for y in range(15, 27):
-		var width := max(0, (y - 15) * 2)
-		var left_x := 16 - width/2 - 1
-		var right_x := 16 + width/2 + 1
+		var width: int = (y - 15) * 2
+		var left_x: int = 16 - width // 2 - 1
+		var right_x: int = 16 + width // 2 + 1
 		if left_x >= 0 and left_x < 32:
 			img.set_pixel(left_x, y, Color(0, 0, 0))
 		if right_x >= 0 and right_x < 32:


### PR DESCRIPTION
Explicitly type `width`, `left_x`, and `right_x` as `int` and use integer division to resolve type inference errors.

This change addresses "Cannot infer the type of variable" errors and "Variant type inference" warnings (treated as errors) on lines 92-94 in `ui/TargetSelector.gd` by ensuring all related calculations produce integer values.

---
<a href="https://cursor.com/background-agent?bcId=bc-38554c87-3e90-42e1-9320-a3eec5a27064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-38554c87-3e90-42e1-9320-a3eec5a27064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

