### PR TITLE
Check for errors

### DIFF
--- a/scripts/Battle.gd
+++ b/scripts/Battle.gd
@@ -64,8 +64,8 @@ const SpriteAnimator := preload("res://fx/SpriteAnimator.gd")
 const AnimatedFrames := preload("res://scripts/AnimatedFrames.gd")
 const PortraitLoader := preload("res://scripts/PortraitLoader.gd")
 
-@onready var cmd: CommandMenu = preload("res://ui/CommandMenu.gd").new()
-@onready var target_selector: Control = preload("res://ui/TargetSelector.gd").new()
+@onready var cmd: CommandMenu = CommandMenu.new()
+@onready var target_selector: Control = TargetSelector.new()
 
 # --- layout (tuned for 1152x648 window) ---
 const ENEMY_SLOTS := [Vector2(420, 180), Vector2(730, 180)]

--- a/ui/TargetSelector.gd
+++ b/ui/TargetSelector.gd
@@ -83,15 +83,15 @@ func _create_arrow_texture() -> Texture2D:
 	# Draw a yellow arrow (inverted V shape pointing down)
 	for y in range(16, 26):
 		var width: int = (y - 15) * 2
-		for x in range(16 - width // 2, 16 + width // 2 + 1):
+		for x in range(16 - width / 2, 16 + width / 2 + 1):
 			if x >= 0 and x < 32:
 				img.set_pixel(x, y, Color(1, 1, 0))
 	
 	# Add black outline
 	for y in range(15, 27):
 		var width: int = (y - 15) * 2
-		var left_x: int = 16 - width // 2 - 1
-		var right_x: int = 16 + width // 2 + 1
+		var left_x: int = 16 - width / 2 - 1
+		var right_x: int = 16 + width / 2 + 1
 		if left_x >= 0 and left_x < 32:
 			img.set_pixel(left_x, y, Color(0, 0, 0))
 		if right_x >= 0 and right_x < 32:


### PR DESCRIPTION
Corrects script instantiation in `Battle.gd` and fixes division operator errors in `TargetSelector.gd`.

`preload()` was incorrectly used for script classes that should be instantiated directly, leading to "Could not resolve script" errors. Additionally, integer division `//` was causing "Expected expression after '/' operator" errors in `range()` arguments where standard division `/` was expected.

---
<a href="https://cursor.com/background-agent?bcId=bc-3eb93575-5c0d-4263-9056-6d03d9e432ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3eb93575-5c0d-4263-9056-6d03d9e432ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Instantiate `CommandMenu` and `TargetSelector` via constructors and replace integer division with standard division in `TargetSelector` arrow drawing.
> 
> - **UI Initialization**:
>   - In `scripts/Battle.gd`, instantiate `CommandMenu` and `TargetSelector` with `CommandMenu.new()` and `TargetSelector.new()` instead of `preload(...).new()`.
> - **Target Selector Rendering**:
>   - In `ui/TargetSelector.gd`, replace integer division (`// 2`) with standard division (`/ 2`) for arrow width/outline calculations during texture generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ce0b4c43d0f6b2eedbca3c52f0a886dd8416913. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->