### PR TITLE
Update package swift for app icon

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version: 5.6
+import PackageDescription
+import AppleProductTypes
+
+let package = Package(
+    name: "My App",
+    platforms: [
+        .iOS("15.2")
+    ],
+    products: [
+        .iOSApplication(
+            name: "My App",
+            targets: ["AppModule"],
+            bundleIdentifier: "com.example.MyApp",
+            displayVersion: "1.0",
+            bundleVersion: "1",
+            appIcon: .placeholder(icon: .game),
+            accentColor: .presetColor(.purple),
+            supportedDeviceFamilies: [
+                .pad,
+                .phone
+            ],
+            supportedInterfaceOrientations: [
+                .portrait,
+                .landscapeRight,
+                .landscapeLeft,
+                .portraitUpsideDown(.when(deviceFamilies: [.pad]))
+            ]
+        )
+    ],
+    targets: [
+        .executableTarget(
+            name: "AppModule",
+            path: "."
+        )
+    ]
+)


### PR DESCRIPTION
Add `Package.swift` with the correct Swift Playgrounds 4.0+ configuration, including the `.game` app icon.

---
<a href="https://cursor.com/background-agent?bcId=bc-284f9515-5726-4849-b1ca-89b67dd394aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-284f9515-5726-4849-b1ca-89b67dd394aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

